### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The argument must be a function taking a [`Buffer`][buffer] and a callback funct
 *file*: `Object` ([vinyl file](https://github.com/wearefractal/vinyl#file) object)  
 *callback*: `Function`
 
-When [`file.contents`](https://github.com/wearefractal/vinyl#optionscontents) is a [`Buffer`][buffer], it will call *transformFunction*, passing file.contents as the first argument.
+When `file.contents` is a [`Buffer`][buffer], it will call *transformFunction*, passing file.contents as the first argument.
 
 When `file.contents` is a [`Stream`][buffer], it will call *transformFunction*, passing the buffered `file.contents` as the first argument.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Dependency Status](https://img.shields.io/david/shinnn/vinyl-bufferstream.svg?style=flat&label=deps)](https://david-dm.org/shinnn/vinyl-bufferstream)
 [![devDependency Status](https://img.shields.io/david/dev/shinnn/vinyl-bufferstream.svg?style=flat&label=devDeps)](https://david-dm.org/shinnn/vinyl-bufferstream#info=devDependencies)
 
-Deal with [vinyl file](https://github.com/wearefractal/vinyl) contents, regardless of whether it is Buffer/Stream
+> Deal with [vinyl file](https://github.com/wearefractal/vinyl) contents, regardless of whether they are a Buffer or Stream
 
 ```javascript
 var through = require('through2');
@@ -53,29 +53,29 @@ var VinylBufferStream = require('vinyl-bufferstream');
 *transformFunction*: `Function`  
 Return: `Function`
 
-The argument must be a function taking a [`Buffer`][buffer] and a callback function as its first and second argument, which calls the callback function with passing [Node](http://nodejs.org/)-style callback arguments (`error, result`).
+The argument must be a function taking a [`Buffer`][buffer] and a callback function as it's first and second arguments, respectively. The callback will be invoked with [Node](http://nodejs.org/)-style callback arguments (`error, result`), where `result` is the buffered `file.contents`.
 
 #### vinylBufferStream(*file*, *callback*)
 
 *file*: `Object` ([vinyl file](https://github.com/wearefractal/vinyl#file) object)  
 *callback*: `Function`
 
-When the [`file.contents`](https://github.com/wearefractal/vinyl#optionscontents) is a [`Buffer`][buffer], it will call the *transformFunction* with passing file.contents to the first argument.
+When [`file.contents`](https://github.com/wearefractal/vinyl#optionscontents) is a [`Buffer`][buffer], it will call *transformFunction*, passing file.contents as the first argument.
 
-When the `file.contents` is a [`Stream`][buffer], it will call the *transformFunction* with passing the buffered stream of file.contents to the first argument.
+When `file.contents` is a [`Stream`][buffer], it will call *transformFunction*, passing the buffered `file.contents` as the first argument.
 
-When the `file.contents` is a [`Stream`][stream], it won't call the *transformFunction*.
+When `file.contents` is`null`, it won't call the *transformFunction*.
 
 ##### callback(err, contents)
 
 *error*: `Error` or `null`  
 *contents*: [`Buffer`][buffer] or [`Stream`][stream]
 
-When the `file.contents` is a [`Buffer`][buffer], *contents* will be a result that *transformFunction* produces.
+When `file.contents` is a [`Buffer`][buffer], *contents* will be a result that *transformFunction* produces.
 
-When the `file.contents` is a [`Stream`][stream], *contents* will be a stream that emits a data *transformFunction* produces.
+When `file.contents` is a [`Stream`][stream], *contents* will be a stream that emits the data *transformFunction* produces.
 
-When the `file.contents` is `null`, *contents* will be `null`.
+When `file.contents` is `null`, *contents* will be `null`.
 
 ```javascript
 var gulp = require('gulp');
@@ -123,9 +123,9 @@ gulp.task('stream', function() {
 
 ## License
 
-Copyright (c) 2014 - 2015 [Shinnosuke Watanabe](https://github.com/shinnn)
+Copyright (c) 2014 - 2016 [Shinnosuke Watanabe](https://github.com/shinnn)
 
 Licensed under [the MIT License](./LICENSE).
 
-[buffer]: https://iojs.org/api/buffer.html#buffer_class_buffer
-[stream]: https://iojs.org/api/stream.html
+[buffer]: https://nodejs.org/api/buffer.html
+[stream]: https://nodejs.org/api/stream.html

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Dependency Status](https://img.shields.io/david/shinnn/vinyl-bufferstream.svg?style=flat&label=deps)](https://david-dm.org/shinnn/vinyl-bufferstream)
 [![devDependency Status](https://img.shields.io/david/dev/shinnn/vinyl-bufferstream.svg?style=flat&label=devDeps)](https://david-dm.org/shinnn/vinyl-bufferstream#info=devDependencies)
 
-> Deal with [vinyl file](https://github.com/wearefractal/vinyl) contents, regardless of whether they are a Buffer or Stream
+Deal with [vinyl file](https://github.com/wearefractal/vinyl) contents, regardless of whether they are a Buffer or Stream
 
 ```javascript
 var through = require('through2');

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "helper"
   ],
   "dependencies": {
-    "bufferstreams": "1.0.1"
+    "readable-stream": "^2.0.5",
+    "vinyl": "^1.1.0"
   },
   "devDependencies": {
     "eslint": "^1.10.3",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,7 @@
     "coverage": "istanbul cover test.js",
     "coveralls": "${npm_package_scripts_coverage} && istanbul-coveralls"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/shinnn/vinyl-bufferstream/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "files": [
     "index.js"
   ],
@@ -37,14 +32,14 @@
     "bufferstreams": "1.0.1"
   },
   "devDependencies": {
-    "eslint": "^0.14.1",
-    "istanbul": "^0.3.5",
+    "eslint": "^1.10.3",
+    "istanbul": "^0.4.2",
     "istanbul-coveralls": "^1.0.1",
-    "jscs": "^1.11.2",
-    "simple-bufferstream": "0.0.4",
-    "tap-spec": "^2.2.1",
-    "tape": "^3.5.0",
-    "vinyl": "^0.4.6"
+    "jscs": "^2.8.0",
+    "simple-bufferstream": "^1.0.0",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.4.0",
+    "vinyl": "^1.1.0"
   },
   "jscsConfig": {
     "preset": "google",

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 /* eslint new-cap:0 no-new:0 */
 'use strict';
 
-var bufferToStream = require('simple-bufferstream');
+var sbuff = require('simple-bufferstream');
 var File = require('vinyl');
 var test = require('tape');
 var VinylBufferStream = require('./');
@@ -25,7 +25,7 @@ test('VinylBufferStream()', function(t) {
     function() {
       new VinylBufferStream('foo');
     },
-    /TypeError.*foo is not a function/,
+    /TypeError.*expects a function/,
     'should throw a type error when the first argument is not a function.'
   );
 
@@ -33,7 +33,7 @@ test('VinylBufferStream()', function(t) {
     function() {
       new VinylBufferStream();
     },
-    /TypeError.*must be a function\./,
+    /TypeError.*expects a function/,
     'should throw a type error when it takes no arguments.'
   );
 });
@@ -68,7 +68,7 @@ test('instance of VinylBufferStream()', function(t) {
     );
   });
 
-  vinylBufferStream(new File({contents: bufferToStream('a')}), function(err, contents) {
+  vinylBufferStream(new File({contents: sbuff('a')}), function(err, contents) {
     t.strictEqual(err, null, 'should accept vinyl file in stream mode.');
     contents.on('data', function(data) {
       t.equal(
@@ -79,7 +79,7 @@ test('instance of VinylBufferStream()', function(t) {
     });
   });
 
-  vinylBufferStream(new File({contents: bufferToStream('error')}), function(err, contents) {
+  vinylBufferStream(new File({contents: sbuff('error')}), function(err, contents) {
     t.deepEqual(
       [err, contents],
       [tmpError, undefined],
@@ -97,7 +97,7 @@ test('instance of VinylBufferStream()', function(t) {
 
   t.throws(
     vinylBufferStream.bind(null, new File(), 'foo'),
-    /TypeError.*foo is not a function.*must be a function\./,
+    /TypeError.*must be a function\./,
     'should throw a type error when the second argument is not a function.'
   );
 });


### PR DESCRIPTION
`vinyl` and `readable-stream` are dependancies of gulp itself.

Removed the [bufferstreams](https://github.com/nfroidure/BufferStreams) module as a dependancy in favour of [rvaggs simple-bufferstream](https://github.com/rvagg/node-simple-bufferstream) which is already a dev dependancy.
